### PR TITLE
Deal with sids that are reported that may not have a model

### DIFF
--- a/components/xiaomi.py
+++ b/components/xiaomi.py
@@ -242,7 +242,10 @@ class XiaomiGateway:
         for sid in sids:
             cmd = '{"cmd":"read","sid":"' + sid + '"}'
             resp = self._send_cmd(cmd, "read_ack")
-            model = resp["model"]
+            try:
+              model = resp["model"]
+            except KeyError:
+             continue
             
             if model == '':
                 model = 'cube'


### PR DESCRIPTION
Without this change my gateway reported a sid which did not have a model. As a result the entire component broke. This change makes this more robust (it'll skip the error'd SID gracefully).