### PR TITLE
Validate data from gateway and refactoring

### DIFF
--- a/components/binary_sensor/xiaomi.py
+++ b/components/binary_sensor/xiaomi.py
@@ -121,8 +121,9 @@ class XiaomiMotionSensor(XiaomiDevice, BinarySensorDevice):
     def update(self):
         data = self.xiaomi_hub.get_from_hub(self._sid)
         if data is None:
+            if self._state:
+                self.schedule_update_ha_state()
             self._state = False
-            self.schedule_update_ha_state()
         self.push_data(data)
 
     @asyncio.coroutine

--- a/components/binary_sensor/xiaomi.py
+++ b/components/binary_sensor/xiaomi.py
@@ -65,7 +65,7 @@ class XiaomiMotionSensor(XiaomiDevice, BinarySensorDevice):
     def __init__(self, device, xiaomi_hub, hass):
         """Initialize the XiaomiMotionSensor."""
         self._state = False
-        self._battery = -1
+        self._battery = None
         self._hass = hass
         XiaomiDevice.__init__(self, device, 'Motion Sensor', xiaomi_hub)
 
@@ -136,7 +136,7 @@ class XiaomiDoorSensor(XiaomiDevice, BinarySensorDevice):
     def __init__(self, device, xiaomi_hub):
         """Initialize the XiaomiDoorSensor."""
         self._state = False
-        self._battery = -1
+        self._battery = None
         XiaomiDevice.__init__(self, device, 'Door Window Sensor', xiaomi_hub)
 
     @property

--- a/components/binary_sensor/xiaomi.py
+++ b/components/binary_sensor/xiaomi.py
@@ -122,8 +122,9 @@ class XiaomiMotionSensor(XiaomiDevice, BinarySensorDevice):
         data = self.xiaomi_hub.get_from_hub(self._sid)
         if data is None:
             if self._state:
+                self._state = False
                 self.schedule_update_ha_state()
-            self._state = False
+            return
         self.push_data(data)
 
     @asyncio.coroutine

--- a/components/binary_sensor/xiaomi.py
+++ b/components/binary_sensor/xiaomi.py
@@ -121,7 +121,8 @@ class XiaomiMotionSensor(XiaomiDevice, BinarySensorDevice):
     def update(self):
         data = self.xiaomi_hub.get_from_hub(self._sid)
         if data is None:
-            return
+            self._state = False
+            self.schedule_update_ha_state()
         self.push_data(data)
 
     @asyncio.coroutine

--- a/components/binary_sensor/xiaomi.py
+++ b/components/binary_sensor/xiaomi.py
@@ -82,11 +82,11 @@ class XiaomiMotionSensor(XiaomiDevice, BinarySensorDevice):
         if 'status' in data:
             value = data['status']
             if value == 'motion':
+                self._hass.loop.create_task(self.async_poll_status())
                 if self._state:
                     return False
                 else:
                     self._state = True
-                    self._hass.loop.create_task(self.async_poll_status())
                     return True
             elif value == 'no_motion':
                 if not self._state:
@@ -126,9 +126,8 @@ class XiaomiMotionSensor(XiaomiDevice, BinarySensorDevice):
 
     @asyncio.coroutine
     def async_poll_status(self):
-        while self._state:
-            yield from asyncio.sleep(10)
-            self.update()
+        yield from asyncio.sleep(10)
+        self.update()
 
 class XiaomiDoorSensor(XiaomiDevice, BinarySensorDevice):
     """Representation of a XiaomiDoorSensor."""
@@ -205,9 +204,8 @@ class XiaomiButton(XiaomiDevice, BinarySensorDevice):
         if state == 'long_click_press':
             self._is_down = True
             self.schedule_update_ha_state()
-            return
-
-        if state == 'long_click_release':
+            click_type = 'long_click_press'
+        elif state == 'long_click_release':
             self._is_down = False
             self.schedule_update_ha_state()
             click_type = 'hold'

--- a/components/binary_sensor/xiaomi.py
+++ b/components/binary_sensor/xiaomi.py
@@ -30,7 +30,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             elif (model == '86sw1'):
                 add_devices([XiaomiButton(device, 'Wall Switch', 'channel_0', hass, gateway)])
             elif (model == '86sw2'):
-                add_devices([XiaomiButton(device, 'Wall Switch (Left)', 'channel_0', hass, gateway), 
+                add_devices([XiaomiButton(device, 'Wall Switch (Left)', 'channel_0', hass, gateway),
                     XiaomiButton(device, 'Wall Switch (Right)', 'channel_1', hass, gateway)])
 
 class XiaomiDevice(Entity):
@@ -82,14 +82,14 @@ class XiaomiMotionSensor(XiaomiDevice, BinarySensorDevice):
         if 'status' in data:
             value = data['status']
             if value == 'motion':
-                if self._state == True: 
+                if self._state == True:
                     return False
                 else:
                     self._state = True
                     self._hass.loop.create_task(self.async_poll_status())
                     return True
             elif value == 'no_motion':
-                if self._state == False: 
+                if self._state == False:
                     return False
                 else:
                     self._state = False
@@ -100,7 +100,7 @@ class XiaomiMotionSensor(XiaomiDevice, BinarySensorDevice):
                 self._state = False
                 return True
             else:
-                return False     
+                return False
 
     @property
     def device_state_attributes(self):
@@ -111,7 +111,7 @@ class XiaomiMotionSensor(XiaomiDevice, BinarySensorDevice):
 
     def push_data(self, data):
         """Push from Hub"""
-        if self.parse_data(data) == True:
+        if self.parse_data(data):
             self.schedule_update_ha_state()
 
         if 'battery' in data:
@@ -120,6 +120,8 @@ class XiaomiMotionSensor(XiaomiDevice, BinarySensorDevice):
     #For Polling
     def update(self):
         data = self.xiaomi_hub.get_from_hub(self._sid)
+        if data is None:
+            return
         self.push_data(data)
 
     @asyncio.coroutine
@@ -163,7 +165,7 @@ class XiaomiDoorSensor(XiaomiDevice, BinarySensorDevice):
                 self._state = False
                 return True
             else:
-                return False     
+                return False
 
     @property
     def device_state_attributes(self):
@@ -174,7 +176,7 @@ class XiaomiDoorSensor(XiaomiDevice, BinarySensorDevice):
 
     def push_data(self, data):
         """Push from Hub"""
-        if self.parse_data(data) == True:
+        if self.parse_data(data):
             self.schedule_update_ha_state()
 
         if 'battery' in data:

--- a/components/binary_sensor/xiaomi.py
+++ b/components/binary_sensor/xiaomi.py
@@ -82,21 +82,21 @@ class XiaomiMotionSensor(XiaomiDevice, BinarySensorDevice):
         if 'status' in data:
             value = data['status']
             if value == 'motion':
-                if self._state == True:
+                if self._state:
                     return False
                 else:
                     self._state = True
                     self._hass.loop.create_task(self.async_poll_status())
                     return True
             elif value == 'no_motion':
-                if self._state == False:
+                if not self._state:
                     return False
                 else:
                     self._state = False
                     return True
 
         if 'no_motion' in data:
-            if self._state == True:
+            if self._state:
                 self._state = False
                 return True
             else:
@@ -126,7 +126,7 @@ class XiaomiMotionSensor(XiaomiDevice, BinarySensorDevice):
 
     @asyncio.coroutine
     def async_poll_status(self):
-        while self._state == True:
+        while self._state:
             yield from asyncio.sleep(10)
             self.update()
 
@@ -154,14 +154,14 @@ class XiaomiDoorSensor(XiaomiDevice, BinarySensorDevice):
 
         value = data['status']
         if value == 'open' or value == 'no_close':
-            if self._state == True:
+            if self._state:
                 return False
             else:
                 self._state = True
                 return True
 
         if value == 'close':
-            if self._state == True:
+            if self._state:
                 self._state = False
                 return True
             else:

--- a/components/light/xiaomi.py
+++ b/components/light/xiaomi.py
@@ -70,7 +70,7 @@ class XiaomiGatewayLight(XiaomiDevice, Light):
         XiaomiDevice.__init__(self, device, name, xiaomi_hub)
 
     def parse_data(self, data):
-        if not self._data_key in data:
+        if self._data_key not in data:
             return False
 
         if data['rgb'] == 0:
@@ -98,11 +98,13 @@ class XiaomiGatewayLight(XiaomiDevice, Light):
 
     def push_data(self, data):
         """Push from Hub"""
-        if self.parse_data(data) == True:
+        if self.parse_data(data):
             self.schedule_update_ha_state()
 
     def update(self):
         data = self.xiaomi_hub.get_from_hub(self._sid)
+        if data is None:
+            return
         self.push_data(data)
 
     @property

--- a/components/light/xiaomi.py
+++ b/components/light/xiaomi.py
@@ -73,14 +73,14 @@ class XiaomiGatewayLight(XiaomiDevice, Light):
         if self._data_key not in data:
             return False
 
-        if data['rgb'] == 0:
-            if self._state == False:
+        if data[self._data_key] == 0:
+            if not self._state:
                 return False
             else:
                 self._state = False
                 return True
 
-        rgbhexstr = "%x" % data['rgb']
+        rgbhexstr = "%x" % data[self._data_key]
         if len(rgbhexstr) == 7:
             # fromhex can't deal with odd strings
             rgbhexstr = '0' + rgbhexstr

--- a/components/light/xiaomi.py
+++ b/components/light/xiaomi.py
@@ -6,7 +6,7 @@ Developed by Rave from Lazcad.com
 import logging
 import struct
 import binascii
-from homeassistant.helpers.entity import Entity
+from homeassistant.components.xiaomi import XiaomiDevice
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_EFFECT,
     ATTR_RGB_COLOR, ATTR_WHITE_VALUE, ATTR_XY_COLOR, SUPPORT_BRIGHTNESS,
@@ -17,39 +17,14 @@ _LOGGER = logging.getLogger(__name__)
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Perform the setup for Xiaomi devices."""
-
-    XIAOMI_GATEWAYS = hass.data['XIAOMI_GATEWAYS']
-    for (ip, gateway) in XIAOMI_GATEWAYS.items():
+    devices = []
+    for (ip, gateway) in hass.data['XIAOMI_GATEWAYS']:
         for device in gateway.XIAOMI_DEVICES['light']:
             model = device['model']
             if (model == 'gateway'):
-                add_devices([XiaomiGatewayLight(device, 'Gateway Light', gateway)])
+                devices.append(XiaomiGatewayLight(device, 'Gateway Light', gateway))
+    add_devices(devices)
 
-class XiaomiDevice(Entity):
-    """Representation a base Xiaomi device."""
-
-    def __init__(self, device, name, xiaomi_hub):
-        """Initialize the xiaomi device."""
-        self._sid = device['sid']
-        self._name = '{}_{}'.format(name, self._sid)
-        self.parse_data(device['data'])
-        self.xiaomi_hub = xiaomi_hub
-        xiaomi_hub.XIAOMI_HA_DEVICES[self._sid].append(self)
-
-    @property
-    def name(self):
-        """Return the name of the device."""
-        return self._name
-
-    @property
-    def should_poll(self):
-        return False
-
-    def push_data(self, data):
-        return True
-
-    def parse_data(self, data):
-        return True
 
 class XiaomiGatewayLight(XiaomiDevice, Light):
     """Representation of a XiaomiGatewayLight."""
@@ -95,17 +70,6 @@ class XiaomiGatewayLight(XiaomiDevice, Light):
         self._state = True
 
         return True
-
-    def push_data(self, data):
-        """Push from Hub"""
-        if self.parse_data(data):
-            self.schedule_update_ha_state()
-
-    def update(self):
-        data = self.xiaomi_hub.get_from_hub(self._sid)
-        if data is None:
-            return
-        self.push_data(data)
 
     @property
     def brightness(self):
@@ -164,10 +128,8 @@ class XiaomiGatewayLight(XiaomiDevice, Light):
 
         if self.xiaomi_hub.write_to_hub(self._sid, self._data_key, rgbhex):
             self._state = True
-            self.schedule_update_ha_state()
 
     def turn_off(self, **kwargs):
         """Turn the light off."""
         if self.xiaomi_hub.write_to_hub(self._sid, self._data_key, 0):
             self._state = False
-            self.schedule_update_ha_state()

--- a/components/sensor/xiaomi.py
+++ b/components/sensor/xiaomi.py
@@ -19,7 +19,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             model = device['model']
             if (model == 'sensor_ht'):
                 add_devices([
-                    XiaomiSensor(device, 'Temperature', 'temperature', gateway), 
+                    XiaomiSensor(device, 'Temperature', 'temperature', gateway),
                     XiaomiSensor(device, 'Humidity', 'humidity', gateway)])
 
 class XiaomiDevice(Entity):
@@ -66,7 +66,7 @@ class XiaomiSensor(XiaomiDevice, Entity):
     @property
     def unit_of_measurement(self):
         if self._data_key == 'temperature':
-            return TEMP_CELSIUS 
+            return TEMP_CELSIUS
         elif self._data_key == 'humidity':
             return '%'
 
@@ -80,7 +80,7 @@ class XiaomiSensor(XiaomiDevice, Entity):
 
     def push_data(self, data):
         """Push from Hub"""
-        if self.parse_data(data) == True:
+        if self.parse_data(data):
             self.schedule_update_ha_state()
 
         if 'battery' in data:
@@ -95,5 +95,7 @@ class XiaomiSensor(XiaomiDevice, Entity):
 
     def update(self):
         data = self.xiaomi_hub.get_from_hub(self._sid)
+        if data is None:
+            return
         self.push_data(data)
 

--- a/components/sensor/xiaomi.py
+++ b/components/sensor/xiaomi.py
@@ -55,7 +55,7 @@ class XiaomiSensor(XiaomiDevice, Entity):
         """Initialize the XiaomiSensor."""
         self.current_value = 0
         self._data_key = data_key
-        self._battery = -1
+        self._battery = None
         XiaomiDevice.__init__(self, device, name, xiaomi_hub)
 
     @property

--- a/components/switch/xiaomi.py
+++ b/components/switch/xiaomi.py
@@ -24,7 +24,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 add_devices([XiaomiGenericSwitch(device, 'Wall Switch', 'channel_0', gateway)])
             elif (model == 'ctrl_neutral2'):
                 add_devices([
-                    XiaomiGenericSwitch(device, 'Wall Switch Left','channel_0', gateway), 
+                    XiaomiGenericSwitch(device, 'Wall Switch Left','channel_0', gateway),
                     XiaomiGenericSwitch(device, 'Wall Switch Right', 'channel_1', gateway)])
 
 class XiaomiDevice(Entity):
@@ -65,7 +65,7 @@ class XiaomiGenericSwitch(XiaomiDevice, SwitchDevice):
     @property
     def icon(self):
         if self._data_key == 'status':
-           return 'mdi:power-plug'
+            return 'mdi:power-plug'
         else:
             return 'mdi:power-socket'
 
@@ -74,7 +74,7 @@ class XiaomiGenericSwitch(XiaomiDevice, SwitchDevice):
         """Return true if plug is on."""
         return self._state
 
-    def turn_on(self, **kwargs):    
+    def turn_on(self, **kwargs):
         """Turn the switch on."""
         if self.xiaomi_hub.write_to_hub(self._sid, self._data_key, 'on'):
             self._state = True
@@ -93,7 +93,7 @@ class XiaomiGenericSwitch(XiaomiDevice, SwitchDevice):
             self.turn_off()
 
     def parse_data(self, data):
-        if not self._data_key in data:
+        if self._data_key not in data:
             return False
 
         state = True if data[self._data_key] == 'on' else False
@@ -105,9 +105,11 @@ class XiaomiGenericSwitch(XiaomiDevice, SwitchDevice):
 
     def push_data(self, data):
         """Push from Hub"""
-        if self.parse_data(data) == True:
+        if self.parse_data(data):
             self.schedule_update_ha_state()
 
     def update(self):
         data = self.xiaomi_hub.get_from_hub(self._sid)
+        if data is None:
+            return
         self.push_data(data)

--- a/components/xiaomi.py
+++ b/components/xiaomi.py
@@ -231,15 +231,18 @@ class XiaomiGateway:
 
         self._socket = socket
 
-        _LOGGER.info('Discovering Xiaomi Devices')
-        self._discover_devices()
+        trycount = 5
+        for _ in range(trycount):
+            _LOGGER.info('Discovering Xiaomi Devices')
+            if self._discover_devices():
+                break
 
     def _discover_devices(self):
 
         cmd = '{"cmd" : "get_id_list"}'
         resp = self._send_cmd(cmd, "get_id_list_ack")
         if resp is None:
-            return
+            return False
         self.GATEWAY_TOKEN = resp["token"]
         sids = json.loads(resp["data"])
         sids.append(self.GATEWAY_SID)
@@ -283,6 +286,7 @@ class XiaomiGateway:
                 _LOGGER.error('Unsupported devices : {0}'.format(model))
             else:
                 self.XIAOMI_DEVICES[device_type].append(xiaomi_device)
+        return True
 
     def _send_cmd(self, cmd, rtnCmd):
         try:

--- a/components/xiaomi.py
+++ b/components/xiaomi.py
@@ -202,6 +202,7 @@ class XiaomiComponent:
                 if cmd == 'heartbeat' and data['model'] == 'gateway':
                     gateway.GATEWAY_TOKEN = data['token']
                 elif cmd == 'report' or cmd == 'heartbeat':
+                    _LOGGER.debug('Received data {0}'.format(data))
                     self.hass.add_job(self._push_data, gateway, data)
                 else:
                     _LOGGER.error('Unknown multicast data : {0}'.format(data))

--- a/components/xiaomi.py
+++ b/components/xiaomi.py
@@ -301,7 +301,7 @@ class XiaomiGateway:
             if resp['cmd'] == rtnCmd:
                 return resp
             else:
-                _LOGGER.error("Response does not match return cmd. Expected {0}".format(resp['cmd']))
+                _LOGGER.error("Response does not match return cmd. Got {0}".format(resp['cmd']))
         except socket.timeout:
             _LOGGER.error("Cannot connect to Gateway")
             return

--- a/components/xiaomi.py
+++ b/components/xiaomi.py
@@ -210,10 +210,10 @@ class XiaomiComponent:
                 raise
 
     def _push_data(self, gateway, data):
-        sid = data['sid']
         jdata = json.loads(data['data'])
         if jdata is None:
             return
+        sid = data['sid']
         for device in gateway.XIAOMI_HA_DEVICES[sid]:
             device.push_data(jdata)
 

--- a/components/xiaomi.py
+++ b/components/xiaomi.py
@@ -205,7 +205,7 @@ class XiaomiComponent:
                     self.hass.add_job(self._push_data, gateway, data)
                 else:
                     _LOGGER.error('Unknown multicast data : {0}'.format(data))
-            except Exception as e:
+            except Exception:
                 _LOGGER.error('Cannot process multicast message : {0}'.format(data))
                 raise
 
@@ -313,7 +313,7 @@ class XiaomiGateway:
         cmd['data'] = data
         cmd = json.dumps(cmd)
         resp = self._send_cmd(cmd, "write_ack")
-        if resp is None:
+        if not resp or 'data' not in resp:
             return False
         data = resp['data']
         if 'error' in data:
@@ -331,7 +331,7 @@ class XiaomiGateway:
         data = resp["data"]
         try:
             return json.loads(resp["data"])
-        except Exception as e:
+        except Exception:
             _LOGGER.error('Cannot process message got from hub : {0}'.format(data))
 
     def _get_key(self):

--- a/components/xiaomi.py
+++ b/components/xiaomi.py
@@ -313,7 +313,7 @@ class XiaomiGateway:
         cmd['data'] = data
         cmd = json.dumps(cmd)
         resp = self._send_cmd(cmd, "write_ack")
-        if not resp or 'data' not in resp:
+        if resp is None or 'data' not in resp:
             return False
         data = resp['data']
         if 'error' in data:
@@ -325,7 +325,7 @@ class XiaomiGateway:
     def get_from_hub(self, sid):
         cmd = '{ "cmd":"read","sid":"' + sid + '"}'
         resp = self._send_cmd(cmd, "read_ack")
-        if not resp or "data" not in resp:
+        if resp is None or "data" not in resp:
             _LOGGER.error('No data in response from hub {0}'.format(resp))
             return
         data = resp["data"]

--- a/components/xiaomi.py
+++ b/components/xiaomi.py
@@ -215,6 +215,7 @@ class XiaomiComponent:
             return
         sid = data['sid']
         for device in gateway.XIAOMI_HA_DEVICES[sid]:
+            _LOGGER.debug('Received data ({0}): {1}'.format(device.name, jdata))
             device.push_data(jdata)
 
 class XiaomiGateway:


### PR DESCRIPTION
I started to fix the issues reported here:
https://community.home-assistant.io/t/beta-xiaomi-gateway-integration/8213/522?u=danielhiversen
https://community.home-assistant.io/t/beta-xiaomi-gateway-integration/8213/523?u=danielhiversen
Now the code validates the data returned from the gateway, before it starts using it.

While working working on this, I also did some refactoring, and small bug fixes.


One changed behavior here: https://github.com/lazcad/homeassistant/compare/master...Danielhiversen:master#diff-8680cfa5c64c090c5bfc5a8118c9d2eeL127
If connection to the gateway was lost or data from the gateway was None, this loop would never end. Now we will only pull for more data when we have received some data from the gateway. If the connection is lost, we will set the state to False.


Most of the other changes are just details, but would be necessary if you want to add this code to HA main repo.