### PR TITLE
Catch missing gateway

### DIFF
--- a/components/xiaomi.py
+++ b/components/xiaomi.py
@@ -132,7 +132,7 @@ class XiaomiComponent:
                     if sid is None or sid == resp["sid"]:
                         gatewayKey = key
                 if len(key) != 16:
-                   _LOGGER.error('Unknown Xiaomi Gateway {0} found at IP {1}'.format(resp["sid"], resp["ip"]))
+                    _LOGGER.error('Unknown Xiaomi Gateway {0} found at IP {1}'.format(resp["sid"], resp["ip"]))
                     continue
                 _LOGGER.info('Xiaomi Gateway {0} found at IP {1}'.format(resp["sid"], resp["ip"]))
                 self.XIAOMI_GATEWAYS[resp["ip"]] = XiaomiGateway(resp["ip"], resp["port"], resp["sid"], gatewayKey, self._socket)

--- a/components/xiaomi.py
+++ b/components/xiaomi.py
@@ -132,6 +132,7 @@ class XiaomiComponent:
                     if sid is None or sid == resp["sid"]:
                         gatewayKey = key
                 if len(key) != 16:
+                   _LOGGER.errår('Unknown Xiaomi Gateway {0} found at IP {1}'.format(resp["sid"], resp["ip"]))
                     continue
                 _LOGGER.info('Xiaomi Gateway {0} found at IP {1}'.format(resp["sid"], resp["ip"]))
                 self.XIAOMI_GATEWAYS[resp["ip"]] = XiaomiGateway(resp["ip"], resp["port"], resp["sid"], gatewayKey, self._socket)

--- a/components/xiaomi.py
+++ b/components/xiaomi.py
@@ -53,7 +53,7 @@ def setup(hass, config):
     trycount = 5
     for _ in range(trycount):
         comp.discoverGateways()
-        if len(comp.XIAOMI_GATEWAYS) > 0:
+        if len(comp.XIAOMI_GATEWAYS) >= len(gateways):
             break
 
     if len(comp.XIAOMI_GATEWAYS) == 0:

--- a/components/xiaomi.py
+++ b/components/xiaomi.py
@@ -131,7 +131,8 @@ class XiaomiComponent:
                     key = gateway['key']
                     if sid is None or sid == resp["sid"]:
                         gatewayKey = key
-
+                if len(key) != 16:
+                    continue
                 _LOGGER.info('Xiaomi Gateway {0} found at IP {1}'.format(resp["sid"], resp["ip"]))
                 self.XIAOMI_GATEWAYS[resp["ip"]] = XiaomiGateway(resp["ip"], resp["port"], resp["sid"], gatewayKey, self._socket)
 

--- a/components/xiaomi.py
+++ b/components/xiaomi.py
@@ -135,6 +135,8 @@ class XiaomiComponent:
                     _LOGGER.error('Unknown Xiaomi Gateway {0} found at IP {1}'.format(resp["sid"], resp["ip"]))
                     continue
                 _LOGGER.info('Xiaomi Gateway {0} found at IP {1}'.format(resp["sid"], resp["ip"]))
+                if resp["ip"] in self.XIAOMI_GATEWAYS:
+                    continue
                 self.XIAOMI_GATEWAYS[resp["ip"]] = XiaomiGateway(resp["ip"], resp["port"], resp["sid"], gatewayKey, self._socket)
 
         except socket.timeout:

--- a/components/xiaomi.py
+++ b/components/xiaomi.py
@@ -132,7 +132,7 @@ class XiaomiComponent:
                     if sid is None or sid == resp["sid"]:
                         gatewayKey = key
                 if len(key) != 16:
-                   _LOGGER.errår('Unknown Xiaomi Gateway {0} found at IP {1}'.format(resp["sid"], resp["ip"]))
+                   _LOGGER.error('Unknown Xiaomi Gateway {0} found at IP {1}'.format(resp["sid"], resp["ip"]))
                     continue
                 _LOGGER.info('Xiaomi Gateway {0} found at IP {1}'.format(resp["sid"], resp["ip"]))
                 self.XIAOMI_GATEWAYS[resp["ip"]] = XiaomiGateway(resp["ip"], resp["port"], resp["sid"], gatewayKey, self._socket)


### PR DESCRIPTION
If a gateway is discovered that is not in the config (and a sid is given for all gateways in the config), we tried to connect to it with an empty key.