### PR TITLE
Encoded strings for pycrypto

### DIFF
--- a/components/xiaomi.py
+++ b/components/xiaomi.py
@@ -367,8 +367,8 @@ class XiaomiGateway:
         """Update key using token from gateway"""
         from Crypto.Cipher import AES
         init_vector = bytes(bytearray.fromhex('17996d093d28ddb3ba695a2e6f58562e'))
-        encryptor = AES.new(self.key, AES.MODE_CBC, IV=init_vector)
-        ciphertext = encryptor.encrypt(token)
+        encryptor = AES.new(self.key.encode(), AES.MODE_CBC, IV=init_vector)
+        ciphertext = encryptor.encrypt(token.encode())
         self._key = ''.join('{:02x}'.format(x) for x in ciphertext)
 
     def _validate_data(self, data):


### PR DESCRIPTION
I ran into the same issue described in [issue 25](https://github.com/lazcad/homeassistant/issues/25). The key and token getting passed to pycrypto is not properly encoded as a byte string properly.

[The documentation](https://www.dlitz.net/software/pycrypto/api/current/Crypto.Cipher.AES-module.html#new) indicates that these values should be passed as a bytestring.