### PR TITLE
switch LOAD_POWER to float

### DIFF
--- a/components/switch/xiaomi.py
+++ b/components/switch/xiaomi.py
@@ -91,7 +91,7 @@ class XiaomiGenericSwitch(XiaomiDevice, SwitchDevice):
             self._power_consumed = int(data[POWER_CONSUMED])
 
         if LOAD_POWER in data:
-            self._load_power = int(data[LOAD_POWER])
+            self._load_power = float(data[LOAD_POWER])
 
         value = data.get(self._data_key)
         if value is None:


### PR DESCRIPTION
Latest Xiaomi firmware is returning LOAD_POWER as float:
`{"cmd":"read_ack","model":"plug","sid":"xxxxx","short_id":xxxx,"data":"{\"voltage\":3600,\"status\":\"off\",\"inuse\":\"0\",\"power_consumed\":\"809\",\"load_power\":\"0.00\"}"}`

This is causing startup error:
```
Jul 21 11:09:24 xxx scl: self.parse_data(device['data'])
Jul 21 11:09:24 xxx scl: File "/home/homeassistant/.homeassistant/custom_components/switch/xiaomi.py", line 96, in parse_data
Jul 21 11:09:24 xxx scl: self._load_power = int(data[LOAD_POWER])
Jul 21 11:09:24 xxx scl: ValueError: invalid literal for int() with base 10: '0.00'#033[0m
```


