### PR TITLE
simultaneous click of both keys

### DIFF
--- a/components/binary_sensor/xiaomi.py
+++ b/components/binary_sensor/xiaomi.py
@@ -48,6 +48,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             elif model == '86sw2':
                 devices.append(XiaomiButton(device, 'Wall Switch (Left)', 'channel_0', hass, gateway))
                 devices.append(XiaomiButton(device, 'Wall Switch (Right)', 'channel_1', hass, gateway))
+                devices.append(XiaomiButton(device, 'Wall Switch (Both)', 'dual_channel', hass, gateway))
             elif model == 'cube':
                 devices.append(XiaomiCube(device, hass, gateway))
     add_devices(devices)
@@ -262,6 +263,8 @@ class XiaomiButton(XiaomiDevice, BinarySensorDevice):
             click_type = 'single'
         elif value == 'double_click':
             click_type = 'double'
+        elif value == 'both_click':
+            click_type = 'both_click'
 
         self._hass.bus.fire('click', {
             'entity_id': self.entity_id,


### PR DESCRIPTION
Xiaomi Zigbee Double key: added support for simultaneous click of both keys